### PR TITLE
add s390x support in systemcallfilter

### DIFF
--- a/server/src/main/java/org/opensearch/bootstrap/SystemCallFilter.java
+++ b/server/src/main/java/org/opensearch/bootstrap/SystemCallFilter.java
@@ -259,6 +259,7 @@ final class SystemCallFilter {
         Map<String, Arch> m = new HashMap<>();
         m.put("amd64", new Arch(0xC000003E, 0x3FFFFFFF, 57, 58, 59, 322, 317));
         m.put("aarch64", new Arch(0xC00000B7, 0xFFFFFFFF, 1079, 1071, 221, 281, 277));
+        m.put("s390x", new Arch(0x80000016, 0xFFFFFFFF, 2, 190, 11, 354, 348));
         ARCHITECTURES = Collections.unmodifiableMap(m);
     }
 


### PR DESCRIPTION
https://github.com/opensearch-project/OpenSearch/issues/4000

### Description
Helps making OpenSearch Server running on s390x
 
### Issues Resolved
Issue #4000
 
### Check List
- add support for s390x architecture in systemcallfilter

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
